### PR TITLE
return for CrudManager DTOs always instead of entities

### DIFF
--- a/Services/Crud/CrudManager.php
+++ b/Services/Crud/CrudManager.php
@@ -101,7 +101,7 @@ class CrudManager
         $event = new ApiEvent($entity, ApiEvent::ACTION_CREATE);
         $this->eventDispatcher->dispatch(ApiEvent::EVENT_POST_FLUSH, $event);
 
-        return $entity;
+        return $this->dtoManager->createDto($entity, DtoInterface::DTO_GROUP_READ, $this->requestManager->getFields());
     }
 
     /**
@@ -149,7 +149,7 @@ class CrudManager
         $event = new ApiEvent($entity, ApiEvent::ACTION_UPDATE);
         $this->eventDispatcher->dispatch(ApiEvent::EVENT_POST_FLUSH, $event);
 
-        return $entity;
+        return $this->dtoManager->createDto($entity, DtoInterface::DTO_GROUP_READ, $this->requestManager->getFields());
     }
 
     /**


### PR DESCRIPTION
Will help to avoid circular references in new versions of symfony